### PR TITLE
Remove HTMX and implement standard navigation

### DIFF
--- a/backend_portal/fleet_manager/portal/templates/portal/base.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/base.html
@@ -119,96 +119,57 @@
             <div id="sidebar-menu">
               <ul class="sidebar-links" id="simple-bar">
                 <li class="sidebar-main-title"><div><h6>Navigation</h6></div></li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=overview"
-                    data-portal-tab="overview"
-                  >
+                <li class="sidebar-list{% if active_tab == 'overview' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'overview' %} active{% endif %}" href="{% url 'portal-admin' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-home"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-home"></use></svg>
                     <span>Overview</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=customers"
-                    data-portal-tab="customers"
-                    data-portal-url="{% url 'portal-customers' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'customers' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'customers' %} active{% endif %}" href="{% url 'portal-customers' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-users"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-users"></use></svg>
                     <span>Customers</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=vehicles"
-                    data-portal-tab="vehicles"
-                    data-portal-url="{% url 'portal-vehicles' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'vehicles' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'vehicles' %} active{% endif %}" href="{% url 'portal-vehicles' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-widget"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-widget"></use></svg>
                     <span>Vehicles</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=assignments"
-                    data-portal-tab="assignments"
-                    data-portal-url="{% url 'portal-assignments' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'assignments' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'assignments' %} active{% endif %}" href="{% url 'portal-assignments' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-task"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-task"></use></svg>
                     <span>Assignments</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=inspections"
-                    data-portal-tab="inspections"
-                    data-portal-url="{% url 'portal-inspections' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'inspections' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'inspections' %} active{% endif %}" href="{% url 'portal-inspections' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-dashboard"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-dashboard"></use></svg>
                     <span>Inspections</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=inspectors"
-                    data-portal-tab="inspectors"
-                    data-portal-url="{% url 'portal-inspectors' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'inspectors' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'inspectors' %} active{% endif %}" href="{% url 'portal-inspectors' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-team"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-team"></use></svg>
                     <span>Inspectors</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=categories"
-                    data-portal-tab="categories"
-                    data-portal-url="{% url 'portal-categories' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'categories' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'categories' %} active{% endif %}" href="{% url 'portal-categories' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-ui"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-ui"></use></svg>
                     <span>Checklist</span>
                   </a>
                 </li>
-                <li class="sidebar-list">
-                  <a
-                    class="sidebar-link link-nav"
-                    href="?tab=users"
-                    data-portal-tab="users"
-                    data-portal-url="{% url 'portal-users' %}"
-                  >
+                <li class="sidebar-list{% if active_tab == 'users' %} active{% endif %}">
+                  <a class="sidebar-link link-nav{% if active_tab == 'users' %} active{% endif %}" href="{% url 'portal-users' %}">
                     <svg class="stroke-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#stroke-profile"></use></svg>
                     <svg class="fill-icon"><use href="{% static 'assets/svg/icon-sprite.svg' %}#fill-profile"></use></svg>
                     <span>Portal Users</span>

--- a/backend_portal/fleet_manager/portal/templates/portal/base.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/base.html
@@ -202,93 +202,16 @@
       </div>
     </div>
 
-    <div id="portalLoader" class="htmx-indicator position-fixed top-50 start-50 translate-middle">
-      <div class="spinner-border text-primary" role="status"><span class="visually-hidden">Loading...</span></div>
-    </div>
-
     <script src="{% static 'assets/js/jquery.min.js' %}"></script>
     <script src="{% static 'assets/js/bootstrap/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'assets/js/icons/feather-icon/feather.min.js' %}"></script>
     <script src="{% static 'assets/js/icons/feather-icon/feather-icon.js' %}"></script>
     <script src="{% static 'assets/js/config.js' %}"></script>
     <script src="{% static 'assets/js/script.js' %}"></script>
-    <script src="https://unpkg.com/htmx.org@1.9.12"></script>
 
     <script>
-      feather.replace();
-
-      function getCookie(name) {
-        const value = `; ${document.cookie}`;
-        const parts = value.split(`; ${name}=`);
-        if (parts.length === 2) return parts.pop().split(';').shift();
-        return '';
-      }
-
-      function setActiveTab(tab) {
-        document.querySelectorAll('[data-portal-tab]').forEach((link) => {
-          if (link.dataset.portalTab === tab) {
-            link.classList.add('active');
-            link.closest('li')?.classList.add('active');
-          } else {
-            link.classList.remove('active');
-            link.closest('li')?.classList.remove('active');
-          }
-        });
-        document.body.dataset.activeTab = tab;
-      }
-
-      document.body.addEventListener('htmx:configRequest', (event) => {
-        event.detail.headers['X-CSRFToken'] = getCookie('csrftoken');
-        event.detail.target = event.detail.target || '#portalContent';
-        event.detail.verb = event.detail.verb || 'GET';
-        event.detail.indicator = '#portalLoader';
-        const tabAttr = event.detail.requestConfig.elt?.dataset?.portalTabTarget;
-        if (tabAttr) {
-          event.detail.headers['X-Portal-Tab'] = tabAttr;
-        }
-      });
-
-      document.body.addEventListener('htmx:afterSwap', (event) => {
-        const tabAttr = event.detail.requestConfig.elt?.dataset?.portalTab || event.detail.requestConfig.headers['X-Portal-Tab'];
-        if (tabAttr) {
-          setActiveTab(tabAttr);
-          const url = new URL(window.location.href);
-          url.searchParams.set('tab', tabAttr);
-          history.replaceState({}, '', url);
-        }
-      });
-
-      document.querySelectorAll('[data-portal-tab][data-portal-url]').forEach((link) => {
-        link.addEventListener('click', (event) => {
-          event.preventDefault();
-          const tab = link.dataset.portalTab;
-          const url = link.dataset.portalUrl;
-          if (!url) {
-            setActiveTab(tab);
-            const nextUrl = new URL(window.location.href);
-            nextUrl.searchParams.set('tab', tab);
-            history.replaceState({}, '', nextUrl);
-            return;
-          }
-          htmx.ajax('GET', url, { target: '#portalContent', swap: 'innerHTML', indicator: '#portalLoader', headers: { 'X-Portal-Tab': tab } });
-        });
-      });
-
       document.addEventListener('DOMContentLoaded', () => {
-        const initialTab = document.body.dataset.activeTab || 'overview';
-        if (initialTab !== 'overview') {
-          const navLink = document.querySelector(`[data-portal-tab="${initialTab}"][data-portal-url]`);
-          if (navLink) {
-            htmx.ajax('GET', navLink.dataset.portalUrl, {
-              target: '#portalContent',
-              swap: 'innerHTML',
-              indicator: '#portalLoader',
-              headers: { 'X-Portal-Tab': initialTab },
-            });
-          }
-        } else {
-          setActiveTab('overview');
-        }
+        feather.replace();
       });
     </script>
     {% block extra_scripts %}{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/forms/form_page.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/forms/form_page.html
@@ -6,7 +6,7 @@
     <div class="card">
       <div class="card-header pb-0"><h5 class="mb-0">{{ form_title }}</h5></div>
       <div class="card-body">
-        <form action="{{ form_action }}" method="post" hx-boost="true">
+        <form action="{{ form_action }}" method="post">
           {% csrf_token %}
           {{ form.non_field_errors }}
           <div class="row g-3">

--- a/backend_portal/fleet_manager/portal/templates/portal/forms/form_partial.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/forms/form_partial.html
@@ -1,7 +1,7 @@
 <div class="card">
   <div class="card-header pb-0"><h5 class="mb-0">{{ form_title }}</h5></div>
   <div class="card-body">
-    <form action="{{ form_action }}" method="post" hx-boost="true">
+    <form action="{{ form_action }}" method="post">
       {% csrf_token %}
       {{ form.non_field_errors }}
       <div class="row g-3">
@@ -15,7 +15,7 @@
         {% endfor %}
       </div>
       <div class="d-flex justify-content-end gap-2 mt-4">
-        <a class="btn btn-light" href="{{ cancel_url }}" data-portal-tab-target="{{ active_tab }}" hx-get="{{ cancel_url }}" hx-target="#portalContent" hx-swap="innerHTML">Cancel</a>
+        <a class="btn btn-light" href="{{ cancel_url }}">Cancel</a>
         <button class="btn btn-primary" type="submit">{{ submit_label }}</button>
       </div>
     </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/assignments.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/assignments.html
@@ -1,7 +1,9 @@
 {% extends "portal/base.html" %}
 {% block title %}Assignments · Fleet Manager Admin{% endblock %}
 {% block content %}
-<div id="portalContent">
-  {% include "portal/partials/assignments.html" %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/assignments.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/categories.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/categories.html
@@ -1,0 +1,9 @@
+{% extends "portal/base.html" %}
+{% block title %}Checklist Categories · Fleet Manager Admin{% endblock %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/categories.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/customers.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/customers.html
@@ -1,7 +1,9 @@
 {% extends "portal/base.html" %}
 {% block title %}Customers · Fleet Manager Admin{% endblock %}
 {% block content %}
-<div id="portalContent">
-  {% include "portal/partials/customers.html" %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/customers.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/inspections.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/inspections.html
@@ -1,0 +1,9 @@
+{% extends "portal/base.html" %}
+{% block title %}Inspections · Fleet Manager Admin{% endblock %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/inspections.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/inspectors.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/inspectors.html
@@ -1,7 +1,9 @@
 {% extends "portal/base.html" %}
 {% block title %}Inspectors · Fleet Manager Admin{% endblock %}
 {% block content %}
-<div id="portalContent">
-  {% include "portal/partials/inspectors.html" %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/inspectors.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/users.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/users.html
@@ -1,0 +1,9 @@
+{% extends "portal/base.html" %}
+{% block title %}Portal Users · Fleet Manager Admin{% endblock %}
+{% block content %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/users.html" %}
+  </div>
+</div>
+{% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/pages/vehicles.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/pages/vehicles.html
@@ -1,7 +1,9 @@
 {% extends "portal/base.html" %}
 {% block title %}Vehicles · Fleet Manager Admin{% endblock %}
 {% block content %}
-<div id="portalContent">
-  {% include "portal/partials/vehicles.html" %}
+<div class="row g-4">
+  <div class="col-12">
+    {% include "portal/partials/vehicles.html" %}
+  </div>
 </div>
 {% endblock %}

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/assignments.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/assignments.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Assignments</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-assignments-new' %}"
-          data-portal-tab="assignments"
-          data-portal-tab-target="assignments"
-          hx-get="{% url 'portal-assignments-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-assignments-new' %}">
           <i class="fa fa-plus me-2"></i>Create Assignment
         </a>
       </div>
@@ -40,27 +32,12 @@
               <td>{{ a.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-assignments-edit' a.pk %}"
-                    data-portal-tab="assignments"
-                    data-portal-tab-target="assignments"
-                    hx-get="{% url 'portal-assignments-edit' a.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-assignments-edit' a.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-assignments-delete' a.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-assignments-delete' a.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="assignments"
-                  >
+                  <form action="{% url 'portal-assignments-delete' a.pk %}" method="post" onsubmit="return confirm('Delete assignment for {{ a.vehicle.license_plate|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete assignment for {{ a.vehicle.license_plate }}?">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/categories.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/categories.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Checklist Categories</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-categories-new' %}"
-          data-portal-tab="categories"
-          data-portal-tab-target="categories"
-          hx-get="{% url 'portal-categories-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-categories-new' %}">
           <i class="fa fa-plus me-2"></i>Add Category
         </a>
       </div>
@@ -29,25 +21,10 @@
                   <small class="text-muted">Code: {{ c.code }}</small>
                 </div>
                 <div class="d-flex gap-2">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-categories-edit' c.pk %}"
-                    data-portal-tab="categories"
-                    data-portal-tab-target="categories"
-                    hx-get="{% url 'portal-categories-edit' c.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >Edit</a>
-                  <form
-                    action="{% url 'portal-categories-delete' c.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-categories-delete' c.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="categories"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-categories-edit' c.pk %}">Edit</a>
+                  <form action="{% url 'portal-categories-delete' c.pk %}" method="post" onsubmit="return confirm('Delete category {{ c.name|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete category {{ c.name }}?">Delete</button>
+                    <button class="btn btn-outline-danger btn-sm" type="submit">Delete</button>
                   </form>
                 </div>
               </div>
@@ -56,15 +33,7 @@
               <p class="f-light mb-3">{{ c.description|default:"No description." }}</p>
               <div class="d-flex align-items-center justify-content-between mb-2">
                 <h6 class="mb-0">Items</h6>
-                <a
-                  class="btn btn-outline-primary btn-sm"
-                  href="{% url 'portal-checklist-items-new' %}?category={{ c.pk }}"
-                  data-portal-tab="categories"
-                  data-portal-tab-target="categories"
-                  hx-get="{% url 'portal-checklist-items-new' %}?category={{ c.pk }}"
-                  hx-target="#portalContent"
-                  hx-swap="innerHTML"
-                >Add Item</a>
+                <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-checklist-items-new' %}?category={{ c.pk }}">Add Item</a>
               </div>
               <ul class="list-group list-group-flush">
                 {% for item in c.items.all %}
@@ -74,25 +43,10 @@
                       <small class="text-muted">Code: {{ item.code }}{% if item.requires_photo %} · Photo required{% endif %}</small>
                     </div>
                     <div class="d-flex gap-2">
-                      <a
-                        class="btn btn-outline-primary btn-sm"
-                        href="{% url 'portal-checklist-items-edit' item.pk %}"
-                        data-portal-tab="categories"
-                        data-portal-tab-target="categories"
-                        hx-get="{% url 'portal-checklist-items-edit' item.pk %}"
-                        hx-target="#portalContent"
-                        hx-swap="innerHTML"
-                      >Edit</a>
-                      <form
-                        action="{% url 'portal-checklist-items-delete' item.pk %}"
-                        method="post"
-                        hx-post="{% url 'portal-checklist-items-delete' item.pk %}"
-                        hx-target="#portalContent"
-                        hx-swap="innerHTML"
-                        data-portal-tab-target="categories"
-                      >
+                      <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-checklist-items-edit' item.pk %}">Edit</a>
+                      <form action="{% url 'portal-checklist-items-delete' item.pk %}" method="post" onsubmit="return confirm('Delete item {{ item.title|escapejs }}?');">
                         {% csrf_token %}
-                        <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete item {{ item.title }}?">Delete</button>
+                        <button class="btn btn-outline-danger btn-sm" type="submit">Delete</button>
                       </form>
                     </div>
                   </li>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/customers.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/customers.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Customers</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-customers-new' %}"
-          data-portal-tab="customers"
-          data-portal-tab-target="customers"
-          hx-get="{% url 'portal-customers-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-customers-new' %}">
           <i class="fa fa-plus me-2"></i>Create Customer
         </a>
       </div>
@@ -45,27 +37,12 @@
               <td>{{ customer.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-customers-edit' customer.pk %}"
-                    data-portal-tab="customers"
-                    data-portal-tab-target="customers"
-                    hx-get="{% url 'portal-customers-edit' customer.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-customers-edit' customer.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-customers-delete' customer.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-customers-delete' customer.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="customers"
-                  >
+                  <form action="{% url 'portal-customers-delete' customer.pk %}" method="post" onsubmit="return confirm('Delete {{ customer.legal_name|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete {{ customer.legal_name }}?">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/inspections.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/inspections.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Inspections</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-inspections-new' %}"
-          data-portal-tab="inspections"
-          data-portal-tab-target="inspections"
-          hx-get="{% url 'portal-inspections-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-inspections-new' %}">
           <i class="fa fa-plus me-2"></i>Log Inspection
         </a>
       </div>
@@ -42,27 +34,12 @@
               <td>{{ i.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-inspections-edit' i.pk %}"
-                    data-portal-tab="inspections"
-                    data-portal-tab-target="inspections"
-                    hx-get="{% url 'portal-inspections-edit' i.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-inspections-edit' i.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-inspections-delete' i.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-inspections-delete' i.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="inspections"
-                  >
+                  <form action="{% url 'portal-inspections-delete' i.pk %}" method="post" onsubmit="return confirm('Delete inspection {{ i.reference|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete inspection {{ i.reference }}?">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/inspectors.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/inspectors.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Inspectors</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-inspectors-new' %}"
-          data-portal-tab="inspectors"
-          data-portal-tab-target="inspectors"
-          hx-get="{% url 'portal-inspectors-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-inspectors-new' %}">
           <i class="fa fa-plus me-2"></i>Add Inspector
         </a>
       </div>
@@ -46,27 +38,12 @@
               <td>{{ inspector.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-inspectors-edit' inspector.pk %}"
-                    data-portal-tab="inspectors"
-                    data-portal-tab-target="inspectors"
-                    hx-get="{% url 'portal-inspectors-edit' inspector.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-inspectors-edit' inspector.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-inspectors-delete' inspector.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-inspectors-delete' inspector.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="inspectors"
-                  >
+                  <form action="{% url 'portal-inspectors-delete' inspector.pk %}" method="post" onsubmit="return confirm('Delete inspector {{ inspector.profile.user.get_full_name|default:inspector.profile.user.username|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete inspector {{ inspector.profile.user.get_full_name|default:inspector.profile.user.username }}?">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/users.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/users.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Portal Users</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-users-new' %}"
-          data-portal-tab="users"
-          data-portal-tab-target="users"
-          hx-get="{% url 'portal-users-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-users-new' %}">
           <i class="fa fa-plus me-2"></i>Create User
         </a>
       </div>
@@ -50,27 +42,12 @@
               <td>{{ u.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-users-edit' u.pk %}"
-                    data-portal-tab="users"
-                    data-portal-tab-target="users"
-                    hx-get="{% url 'portal-users-edit' u.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-users-edit' u.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-users-delete' u.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-users-delete' u.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="users"
-                  >
+                  <form action="{% url 'portal-users-delete' u.pk %}" method="post" onsubmit="return confirm('Delete user {{ u.user.username|escapejs }}? This removes the underlying login.');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete user {{ u.user.username }}? This removes the underlying login.">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>

--- a/backend_portal/fleet_manager/portal/templates/portal/partials/vehicles.html
+++ b/backend_portal/fleet_manager/portal/templates/portal/partials/vehicles.html
@@ -3,15 +3,7 @@
     <div class="d-flex align-items-center justify-content-between flex-wrap gap-2">
       <h5 class="mb-0">Vehicles</h5>
       <div class="d-flex gap-2">
-        <a
-          class="btn btn-primary btn-sm"
-          href="{% url 'portal-vehicles-new' %}"
-          data-portal-tab="vehicles"
-          data-portal-tab-target="vehicles"
-          hx-get="{% url 'portal-vehicles-new' %}"
-          hx-target="#portalContent"
-          hx-swap="innerHTML"
-        >
+        <a class="btn btn-primary btn-sm" href="{% url 'portal-vehicles-new' %}">
           <i class="fa fa-plus me-2"></i>Add Vehicle
         </a>
       </div>
@@ -40,27 +32,12 @@
               <td>{{ vehicle.updated_at|timesince }} ago</td>
               <td class="text-end">
                 <div class="btn-group" role="group">
-                  <a
-                    class="btn btn-outline-primary btn-sm"
-                    href="{% url 'portal-vehicles-edit' vehicle.pk %}"
-                    data-portal-tab="vehicles"
-                    data-portal-tab-target="vehicles"
-                    hx-get="{% url 'portal-vehicles-edit' vehicle.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                  >
+                  <a class="btn btn-outline-primary btn-sm" href="{% url 'portal-vehicles-edit' vehicle.pk %}">
                     Edit
                   </a>
-                  <form
-                    action="{% url 'portal-vehicles-delete' vehicle.pk %}"
-                    method="post"
-                    hx-post="{% url 'portal-vehicles-delete' vehicle.pk %}"
-                    hx-target="#portalContent"
-                    hx-swap="innerHTML"
-                    data-portal-tab-target="vehicles"
-                  >
+                  <form action="{% url 'portal-vehicles-delete' vehicle.pk %}" method="post" onsubmit="return confirm('Delete {{ vehicle.license_plate|escapejs }}?');">
                     {% csrf_token %}
-                    <button class="btn btn-outline-danger btn-sm" type="submit" hx-confirm="Delete {{ vehicle.license_plate }}?">
+                    <button class="btn btn-outline-danger btn-sm" type="submit">
                       Delete
                     </button>
                   </form>


### PR DESCRIPTION
## Purpose
Complete the implementation by removing HTMX-based dynamic navigation and replacing it with standard Django URL routing for a more traditional web application approach.

## Code changes
- **Navigation refactor**: Replaced HTMX-powered sidebar navigation with standard Django URL links using `{% url %}` template tags
- **Active state management**: Implemented server-side active tab detection using `active_tab` template variable instead of client-side JavaScript
- **Form simplification**: Removed HTMX attributes from edit/delete forms and replaced with standard form submissions
- **Confirmation dialogs**: Replaced `hx-confirm` with standard JavaScript `onsubmit` confirmation dialogs
- **JavaScript cleanup**: Removed HTMX library import and related JavaScript functions for tab management and AJAX handling
- **Template streamlining**: Simplified HTML structure by removing HTMX-specific data attributes and loading indicators

The changes affect the base template and all portal partial templates (inspections, inspectors, users, vehicles), converting from a single-page application approach to traditional multi-page navigation.To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/2e9839f8e6cd46f89f19cf3b964ffa4d/aura-zone)

👀 [Preview Link](https://2e9839f8e6cd46f89f19cf3b964ffa4d-aura-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>2e9839f8e6cd46f89f19cf3b964ffa4d</projectId>-->
<!--<branchName>aura-zone</branchName>-->